### PR TITLE
Add BIP39 mnemonic length selection and numbering

### DIFF
--- a/src/secure_qr_tool/config.py
+++ b/src/secure_qr_tool/config.py
@@ -15,7 +15,7 @@ class AppConfig:
     pbkdf2_iterations: int = 600_000
     salt_size_bytes: int = 16
     aes_key_size_bytes: int = 32
-    mnemonic_strength_bits: int = 256
+    mnemonic_default_words: int = 24
     network_check_interval_ms: int = 5_000
     camera_frame_skip: int = 5
     qr_error_correction: str = "M"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -39,6 +39,21 @@ def test_decrypt_rejects_invalid_payload(config: AppConfig):
 def test_mnemonic_checksum_length(config: AppConfig):
     manager = MnemonicManager(config)
     words = manager.generate()
+    assert len(words.split()) == manager.default_word_count
     assert manager.validate(words)
     checksum = manager.checksum(words)
     assert len(checksum) == 6
+
+
+@pytest.mark.parametrize("word_count", MnemonicManager.valid_word_counts())
+def test_mnemonic_word_counts(config: AppConfig, word_count: int):
+    manager = MnemonicManager(config)
+    words = manager.generate(word_count)
+    assert len(words.split()) == word_count
+    assert manager.validate(words)
+
+
+def test_invalid_mnemonic_word_count_raises(config: AppConfig):
+    manager = MnemonicManager(config)
+    with pytest.raises(ValueError):
+        manager.generate(15)


### PR DESCRIPTION
## Summary
- add UI controls to choose between 12, 18, or 24 word BIP39 mnemonics and update generation text dynamically
- display generated recovery phrases as numbered lists while preserving checksum feedback
- extend mnemonic manager to validate supported word counts and add coverage tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d53e0a206c8321a15ee980dcacddde