### PR TITLE
Document encryption payload protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ importing the package in your own scripts.
 
 The cryptographic architecture, including the PBKDF2 parameters, AES-256-GCM
 usage and QR payload hashing strategy, is documented in
-[`docs/cryptography.md`](docs/cryptography.md).
+[`docs/cryptography.md`](docs/cryptography.md). For an implementation-agnostic
+description of the encryption and decryption protocol, including payload
+serialization rules, refer to [`docs/encryption_protocol.md`](docs/encryption_protocol.md).
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- add a formal, language-agnostic specification of the encrypted payload format
- link the README to the new protocol document for easier discovery

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5491d4b04832192ba533e51742d58