### PR TITLE
Add comprehensive testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,51 +62,23 @@ serialization rules, refer to [`docs/encryption_protocol.md`](docs/encryption_pr
 
 ## Tests
 
-The automated checks live under [`tests/`](tests/) and are executed with
-[`pytest`](https://docs.pytest.org/). Run the complete suite with:
+The test suite is powered by [`pytest`](https://docs.pytest.org/) and exercises
+the modules under [`src/secure_qr_tool/`](src/secure_qr_tool/). To reproduce the
+continuous integration setup locally, follow the step-by-step guide in
+[`docs/testing.md`](docs/testing.md). It covers creating a virtual environment,
+installing dependencies, running all tests, filtering individual test cases,
+and generating coverage reports.
+
+If you want a quick overview, the canonical command to execute the entire
+suite from the repository root is:
 
 ```bash
 pytest
 ```
 
-The test modules contain small, focused examples that illustrate how the core
-APIs are meant to be used:
-
-- **`tests/test_qr.py`**
-  - `test_payload_digest_matches_sha256` instantiates
-    [`QRCodeManager`](src/secure_qr_tool/qr.py) and verifies that calling
-    `payload_digest` twice with the same JSON payload returns the same
-    SHA-256 hex digest. The assertion also checks that the digest has the
-    expected 64 hexadecimal characters (256 bits). You can experiment with the
-    helper interactively by running `python -m secure_qr_tool.qr` in a REPL and
-    calling `QRCodeManager().payload_digest('{"salt": "abc"}')`.
-  - `test_save_png_returns_digest` uses `monkeypatch` to replace the optional
-    [`segno`](https://segno.readthedocs.io/) dependency with a dummy QR object.
-    It asserts that `save_png` still returns the digest when the QR code writer
-    is mocked, demonstrating how to test code paths that depend on external
-    libraries.
-- **`tests/test_security.py`**
-  - `test_secure_string_clears_buffer` constructs a [`SecureString`](src/secure_qr_tool/security.py)
-    to show how secrets can be wiped from memory by calling `.clear()`.
-  - `test_encrypt_roundtrip` encrypts a mnemonic using [`CryptoManager`](src/secure_qr_tool/security.py),
-    confirms that the payload contains the `salt`, `nonce`, `ciphertext`, and
-    `version` fields, and then decrypts the payload to prove that the original
-    text is recovered.
-  - `test_decrypt_rejects_invalid_payload` demonstrates the validation logic by
-    passing an incomplete payload to `decrypt` and asserting that a `ValueError`
-    is raised.
-  - `test_mnemonic_checksum_length` and `test_mnemonic_word_counts` use
-    [`MnemonicManager`](src/secure_qr_tool/security.py) to generate recovery
-    phrases. They show how to request the default number of words, validate the
-    phrase, compute its checksum (six characters), and iterate through all
-    supported BIP-39 word counts.
-  - `test_invalid_mnemonic_word_count_raises` provides an example of the guard
-    rails around unsupported word counts by asserting that requesting 15 words
-    raises a `ValueError`.
-
-These examples double as living documentation—reading the tests gives you
-concrete usage patterns for the cryptographic and QR helpers while ensuring
-regressions are caught automatically.
+The test modules double as living documentation—`tests/test_security.py`
+demonstrates the cryptographic helpers, while `tests/test_qr.py` focuses on QR
+payload hashing and persistence.
 
 ## Screenshot
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,88 @@
+# Testing Guide
+
+This document explains how to set up a Python environment for the Secure QR Code
+Tool and how to execute the automated test suite.
+
+## Prerequisites
+
+- Python 3.10 or newer. The project uses features that require at least this
+  version.
+- A recent version of `pip` and `venv` (both ship with the official CPython
+  installers).
+- Git (optional, but recommended if you plan to clone the repository).
+
+## 1. Create and activate a virtual environment
+
+From the repository root, create an isolated Python environment to avoid mixing
+project dependencies with your global site-packages. The following commands use
+a Unix-like shell; adjust the activation command accordingly for Windows (for
+example, `Scripts\\activate.bat`).
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+## 2. Install the project and testing dependencies
+
+Install the package in editable mode so that the `secure_qr_tool` modules are
+available on the Python path. The core runtime dependencies (such as
+`cryptography` and `mnemonic`) are specified in `pyproject.toml` and will be
+pulled in automatically.
+
+```bash
+pip install --upgrade pip
+pip install -e .
+pip install pytest
+```
+
+The GUI-only extras are not required for the tests. If you want to exercise the
+optional QR code rendering paths during manual testing, you can install them
+with `pip install -e .[ui]`.
+
+## 3. Run the full test suite
+
+With the virtual environment active and the dependencies installed, invoke
+`pytest` from the repository root:
+
+```bash
+pytest
+```
+
+Pytest discovers the modules under `tests/` and executes them with the
+configuration declared in `pyproject.toml` (which adds `src/` to `PYTHONPATH`
+and enables quiet output).
+
+## 4. Run specific tests (optional)
+
+Pytest provides several filters if you only need to run a subset of the suite:
+
+- By file: `pytest tests/test_security.py`
+- By test name: `pytest -k roundtrip`
+- With verbose output: `pytest -vv`
+
+## 5. Generate coverage reports (optional)
+
+To check how much of the code base is exercised by the tests, install the
+`pytest-cov` plugin and run pytest with the coverage options:
+
+```bash
+pip install pytest-cov
+pytest --cov=secure_qr_tool --cov-report=term-missing
+```
+
+This command prints a line-by-line summary of uncovered statements so you can
+identify gaps in test coverage.
+
+## 6. Deactivate the virtual environment
+
+When you are done testing, leave the virtual environment so that subsequent
+shell sessions use your global Python interpreter again:
+
+```bash
+deactivate
+```
+
+Following the steps above ensures that you reproduce the same testing
+environment used in continuous integration and can verify changes locally
+before committing them.


### PR DESCRIPTION
## Summary
- add a dedicated testing guide that walks through environment setup, dependency installation, and pytest usage
- update the README test section to reference the new guide while keeping a quickstart command inline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5850b94c88321a19c78317b362183