### PR TITLE
Adopt Argon2id and strengthen encryption protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ security-critical code can be audited and unit tested independently.
 
 ## Features
 
-- **Strong encryption** – AES-256-GCM with PBKDF2-HMAC key derivation and a
-  configurable work factor.
+- **Strong encryption** – AES-256-GCM with Argon2id key derivation by default
+  (PBKDF2 remains available for compatibility) and configurable work factors.
 - **Mnemonic workflow** – generates 24-word recovery phrases using the
   `mnemonic` library and exposes checksum helpers.
 - **QR interoperability** – save encrypted payloads as QR code images when
@@ -54,8 +54,9 @@ importing the package in your own scripts.
 
 ## Cryptographic specification
 
-The cryptographic architecture, including the PBKDF2 parameters, AES-256-GCM
-usage and QR payload hashing strategy, is documented in
+The cryptographic architecture, including the Argon2id defaults, PBKDF2
+compatibility settings, AES-256-GCM usage and QR payload hashing strategy, is
+documented in
 [`docs/cryptography.md`](docs/cryptography.md). For an implementation-agnostic
 description of the encryption and decryption protocol, including payload
 serialization rules, refer to [`docs/encryption_protocol.md`](docs/encryption_protocol.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cryptography>=41",
     "mnemonic>=0.20",
+    "argon2-cffi>=23",
 ]
 
 [project.optional-dependencies]

--- a/src/secure_qr_tool/config.py
+++ b/src/secure_qr_tool/config.py
@@ -12,7 +12,11 @@ class AppConfig:
     app_name: str = "SecureQRCodeTool"
     app_version: str = "3.0"
     min_password_length: int = 12
+    kdf_algorithm: str = "argon2id"
     pbkdf2_iterations: int = 600_000
+    argon2_time_cost: int = 3
+    argon2_memory_cost_kib: int = 131_072
+    argon2_parallelism: int = 2
     salt_size_bytes: int = 16
     aes_key_size_bytes: int = 32
     mnemonic_default_words: int = 24


### PR DESCRIPTION
## Summary
- switch the default password-based key derivation to Argon2id while keeping PBKDF2 compatibility and recording the chosen algorithm in payloads
- bind cipher, version, and KDF metadata via AES-GCM AAD and document the updated protocol defaults
- expand regression tests around nonce validation, downgrade protection, and legacy PBKDF2 payload handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8397cf9e4832184704c46236ced51