### PR TITLE
Handle invalid payload version bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/src/secure_qr_tool/payload.py
+++ b/src/secure_qr_tool/payload.py
@@ -105,12 +105,17 @@ def decode_payload(data: bytes) -> Dict[str, str]:
         raise ValueError("Binary payload length mismatch")
 
     version_bytes = data[offset:end_version]
+    try:
+        version = version_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Version field is not valid UTF-8") from exc
+
     salt = data[end_version:end_salt]
     nonce = data[end_salt:end_nonce]
     ciphertext = data[end_nonce:end_ciphertext]
 
     return {
-        "version": version_bytes.decode("utf-8"),
+        "version": version,
         "kdf": kdf,
         "salt": base64.b64encode(salt).decode("ascii"),
         "nonce": base64.b64encode(nonce).decode("ascii"),

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from secure_qr_tool.payload import decode_payload, encode_components
+
+
+@pytest.fixture()
+def sample_components():
+    return {
+        "version": "v1",
+        "kdf": "argon2id",
+        "salt": b"s" * 16,
+        "nonce": b"n" * 12,
+        "ciphertext": b"c" * 32,
+    }
+
+
+def test_decode_payload_rejects_invalid_utf8_version(sample_components):
+    binary = bytearray(encode_components(**sample_components))
+
+    version_bytes = sample_components["version"].encode("utf-8")
+    header_size = len(binary) - (
+        len(version_bytes)
+        + len(sample_components["salt"])
+        + len(sample_components["nonce"])
+        + len(sample_components["ciphertext"])
+    )
+
+    binary[header_size : header_size + len(version_bytes)] = b"\xff" * len(version_bytes)
+
+    with pytest.raises(ValueError) as excinfo:
+        decode_payload(bytes(binary))
+
+    assert "UTF-8" in str(excinfo.value)
+
+
+def test_decode_payload_rejects_truncated_binary(sample_components):
+    binary = encode_components(**sample_components)
+    truncated = binary[:-1]
+
+    with pytest.raises(ValueError) as excinfo:
+        decode_payload(truncated)
+
+    assert "length mismatch" in str(excinfo.value)
+
+
+def test_decode_payload_base64_roundtrip(sample_components):
+    payload = decode_payload(encode_components(**sample_components))
+
+    assert payload["version"] == sample_components["version"]
+    assert payload["kdf"] == sample_components["kdf"]
+    assert base64.b64decode(payload["salt"]) == sample_components["salt"]
+    assert base64.b64decode(payload["nonce"]) == sample_components["nonce"]
+    assert base64.b64decode(payload["ciphertext"]) == sample_components["ciphertext"]


### PR DESCRIPTION
## Summary
- raise a clear error when binary payload version bytes are not valid UTF-8
- add regression tests covering payload decoding edge cases and round-trips
- ignore Python cache directories committed accidentally

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d862dac5d883218ce8aa8b71070903