### PR TITLE
Allow QR payload decoding with trailing NUL bytes

### DIFF
--- a/src/secure_qr_tool/payload.py
+++ b/src/secure_qr_tool/payload.py
@@ -12,8 +12,16 @@ FORMAT_VERSION = 1
 _HEADER = struct.Struct(">BBHHHI")
 """Header structure: version, kdf enum, version len, salt len, nonce len, ciphertext len."""
 
-_IGNORABLE_SUFFIX = {0x09, 0x0A, 0x0D, 0x20}
-"""ASCII whitespace bytes ignored when decoding (``\t``, ``\n``, ``\r``, space)."""
+_IGNORABLE_SUFFIX = {0x00, 0x09, 0x0A, 0x0D, 0x20}
+"""Suffix bytes ignored when decoding binary payloads.
+
+The QR decoding libraries used by the application occasionally append a
+trailing NUL byte (``0x00``) to the extracted binary data.  The original
+implementation only stripped ASCII whitespace which caused legitimate QR
+payloads to be rejected as malformed.  Including ``0x00`` in the ignored
+set keeps the strict length checks for the actual payload while being
+resilient to this common decoder quirk.
+"""
 
 _KDF_TO_CODE = {"argon2id": 1, "pbkdf2": 2}
 _CODE_TO_KDF = {value: key for key, value in _KDF_TO_CODE.items()}

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -4,7 +4,7 @@ import base64
 
 import pytest
 
-from secure_qr_tool.payload import decode_payload, encode_components
+from secure_qr_tool.payload import decode_payload, encode_components, is_binary_payload
 
 
 @pytest.fixture()
@@ -55,3 +55,15 @@ def test_decode_payload_base64_roundtrip(sample_components):
     assert base64.b64decode(payload["salt"]) == sample_components["salt"]
     assert base64.b64decode(payload["nonce"]) == sample_components["nonce"]
     assert base64.b64decode(payload["ciphertext"]) == sample_components["ciphertext"]
+
+
+def test_decode_payload_ignores_trailing_nul(sample_components):
+    binary = encode_components(**sample_components)
+    padded = binary + b"\x00"
+
+    assert is_binary_payload(padded)
+
+    payload = decode_payload(padded)
+
+    assert payload["version"] == sample_components["version"]
+    assert payload["kdf"] == sample_components["kdf"]


### PR DESCRIPTION
## Summary
- allow QR payload decoding to ignore trailing NUL bytes commonly produced by scanners
- extend payload tests to cover NUL-padded binary data parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d86a3d9edc8321a5dcab33cdc5ee9b