### PR TITLE
Add repository branding frame to generated QR codes

### DIFF
--- a/src/secure_qr_tool/config.py
+++ b/src/secure_qr_tool/config.py
@@ -11,6 +11,7 @@ class AppConfig:
 
     app_name: str = "SecureQRCodeTool"
     app_version: str = "3.0"
+    repo_url: str = "https://github.com/TACITVS/Crypto_QR_Code"
     min_password_length: int = 12
     kdf_algorithm: str = "argon2id"
     pbkdf2_iterations: int = 600_000

--- a/tests/test_qr.py
+++ b/tests/test_qr.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import io
 import json
 import sys
 import types
+
+import pytest
 
 from secure_qr_tool.config import AppConfig
 from secure_qr_tool.qr import QRCodeManager
@@ -35,6 +38,9 @@ def test_save_png_returns_digest(monkeypatch, tmp_path):
         def save(self, *_args, **_kwargs):
             return None
 
+        def to_pil(self, *_args, **_kwargs):
+            raise RuntimeError("Unexpected conversion")
+
     def fake_make(_data, **_kwargs):
         return DummyQR()
 
@@ -46,6 +52,37 @@ def test_save_png_returns_digest(monkeypatch, tmp_path):
     digest = manager.save_png(data, str(tmp_path / "qr.png"))
 
     assert digest == manager.payload_digest(data)
+
+
+def test_save_png_includes_repo_frame(monkeypatch, tmp_path):
+    pillow = pytest.importorskip("PIL.Image")
+    Image = pillow.Image
+
+    class DummyQR:
+        def save(self, stream, *_args, **_kwargs):
+            Image.new("RGB", (120, 120), "white").save(stream, format="PNG")
+
+        def to_pil(self, *_args, **_kwargs):
+            return Image.new("RGB", (120, 120), "white")
+
+    def fake_make(_data, **_kwargs):
+        return DummyQR()
+
+    module = types.SimpleNamespace(make=fake_make)
+    monkeypatch.setitem(sys.modules, "segno", module)
+
+    manager = QRCodeManager(AppConfig())
+    output = tmp_path / "qr.png"
+    manager.save_png("payload", str(output))
+
+    with output.open("rb") as handle:
+        contents = handle.read()
+
+    with Image.open(io.BytesIO(contents)) as image:
+        width, height = image.size
+
+    assert width > 120
+    assert height > 120
 
 
 def test_decode_qr_payload_prefers_base64():


### PR DESCRIPTION
## Summary
- add a configurable repository URL and use it to decorate generated QR code images with a branded frame
- reuse the new PNG rendering helper for both file saving and pixmap generation with graceful fallbacks
- extend the QR test suite to cover the new branding frame logic and ensure legacy behaviour remains intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d871b79e8c8321a80ecd11254e6c25